### PR TITLE
Require cl-mars for cl-loop

### DIFF
--- a/redcode-mode.el
+++ b/redcode-mode.el
@@ -19,6 +19,8 @@
 
 ;;; Code:
 
+(require 'cl-macs)
+
 (defconst redcode-instructions
   '("dat" "mov" "add" "sub" "mul" "div" "mod" "jmp" "jmz" "jmn"
     "djn" "spl" "cmp" "seq" "sne" "slt" "ldp" "stp" "nop")


### PR DESCRIPTION
The function cl-loop is not included in my local Emacs settings by default.

Thanks to https://emacs.stackexchange.com/questions/55706/symbols-function-definition-is-void-cl-loop

This PR ensures that the cl-macs is required before calls to cl-loop.